### PR TITLE
docs: Update `poolAccounting` section (SC-12233)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -63,7 +63,6 @@
   * [WithdrawalManager](technical-resources/pools/withdrawal-manager.md)
   * Accounting
     * [Pool Accounting](technical-resources/pools/accounting/pool-accounting.md)
-    * [Pool Accounting Examples](technical-resources/pools/accounting/pool-accounting-examples.md)
     * [Pool Exchange Rates](technical-resources/pools/accounting/pool-exchange-rates.md)
     * [Advance Global Payment Accounting](technical-resources/pools/accounting/advance-global-payment-accounting.md)
     * [LoanManager Claim Function](technical-resources/pools/accounting/loan-manager-claim-function.md)
@@ -72,6 +71,7 @@
     * [Overview](technical-resources/loan-manager/fixed-term-loan-manager/fixed-term-loan-manager.md)
     * [Claims](technical-resources/loan-manager/fixed-term-loan-manager/fixed-term-claim-function.md)
     * [Advance Payment Accounting](technical-resources/loan-manager/fixed-term-loan-manager/advance-global-payment-accounting.md)
+    * [Accounting Examples](technical-resources/loan-manager/fixed-term-loan-manager/fixed-term-lm-accounting-examples.md)
 * Singletons
   * [Globals](technical-resources/singletons/globals.md)
   * [MapleTreasury](technical-resources/singletons/maple-treasury.md)

--- a/technical-resources/loan-managers/fixed-term-loan-manager/fixed-term-lm-accounting-examples.md
+++ b/technical-resources/loan-managers/fixed-term-loan-manager/fixed-term-lm-accounting-examples.md
@@ -1,11 +1,11 @@
 # Overview
 
-This section is intended to demonstrate multiple scenarios with loans to show how value is represented with `totalAssets`. During each payment, accounting state in the Pool contracts is changed in the following way:
+This section is intended to demonstrate multiple scenarios with loans to show how value is represented with `totalAssets`. During each payment, accounting state in the Fixed Term Manager contract is changed in the following way:
 1. `accountedInterest` is decreased. This is because the $$ outstandingInterest $$ portion of `assetsUnderManagement` must discretely decrease when a payment is made.
 2. `domainStart` is updated to the current timestamp.
 3. `issuanceRate` is updated based on the resulting state.
 4. `domainEnd` is set to the next earliest payment due date.
-5. Cash in the pool increases.
+5. Cash is sent to the pool.
 
 **Note 1**: For all of the below examples, only interest is being paid so outstanding principal (`principalOut`) remains constant.
 
@@ -209,7 +209,7 @@ In this example, there are two outstanding Loans. Loan 2 gets funded on day 5. L
 
 ## Loan 2 Funding
 
-Accounting gets updated in the same way as [Example 4](./pool-accounting-examples.md#loan-2-funding).
+Accounting gets updated in the same way as [Example 4](./fixed-term-lm-accounting-examples.md#loan-2-funding).
 
 ## Loan 1 Payment 1
 
@@ -287,7 +287,7 @@ In this example, there are two different aggregate issuance rates since the issu
 
 ## Loan 2 Funding
 
-Accounting gets updated in the same way as [Example 4](./pool-accounting-examples.md#loan-2-funding).
+Accounting gets updated in the same way as [Example 4](./fixed-term-lm-accounting-examples.md#loan-2-funding).
 
 ## Loan 1 Payment 1
 
@@ -363,7 +363,7 @@ Note that when the second payment is made, it is made after `domainEnd`. This me
 
 ## Loan 2 Funding
 
-Accounting gets updated in the same way as [Example 4](./pool-accounting-examples.md#loan-2-funding).
+Accounting gets updated in the same way as [Example 4](./fixed-term-lm-accounting-examples.md#loan-2-funding).
 
 ## Loan 1 Payment 1
 

--- a/technical-resources/loan-managers/fixed-term-loan-manager/fixed-term-loan-manager.md
+++ b/technical-resources/loan-managers/fixed-term-loan-manager/fixed-term-loan-manager.md
@@ -112,4 +112,3 @@ $$
 \nonumber domainStart \le t \le domainEnd
 \end{align}
 $$
-

--- a/technical-resources/pools/accounting/pool-accounting.md
+++ b/technical-resources/pools/accounting/pool-accounting.md
@@ -32,15 +32,6 @@ $$
 $$
 
 
-where:
-
-
-
-$$
-\begin{align}
-\nonumber domainStart \le t \le domainEnd
-\end{align}
-$$
 
 
 The relationship between the Pool, PoolManager, and LoanManagers regarding value representation is shown in the diagram below.


### PR DESCRIPTION
Moved the pool accounting example page into the FTLM folder because that's what is documeting. The pool accounting is merely a sum of `assets under management` for each of its loan managers.

Then made adjustments in the Pool Accounting section to remove any reference to loan manager specific logic. 