### PR TITLE
feat: example integration with React app

### DIFF
--- a/technical-resources/sdk/usage-guide.md
+++ b/technical-resources/sdk/usage-guide.md
@@ -76,11 +76,22 @@ const poolContract = pool.core.connect(poolAddress, signer);
 const method = await (await poolContract.deposit(depositAmount)).wait();
 ```
 
-## Checking Permissions with Subgraph
+## Checking Permissions and Onboarding
 
-Before a wallet can deposit into a Maple pool, it must have a sufficient `permissionsBitmap` set. This bitmap must meet or exceed the requirements specified by the pool's configuration. You can query the subgraph to check this information.
+Before a wallet can deposit into a Maple pool, it must have a sufficient `permissionsBitmap` set. This is automatically managed when users onboard and verify their accounts on the Maple Webapp. Once verified, all wallets added to the account will receive the necessary permissions. For Syrup pools, permissions are granted after an initial deposit through the UI.
 
-### Example Query
+### Onboarding and Verification
+
+To ensure your wallet has the necessary permissions:
+
+1. **Maple Webapp**: Onboard and verify your account at [Maple Webapp](https://app.maple.finance/). Add your wallets to the account to automatically receive the required permissions.
+2. **Syrup Pools**: Make an initial deposit through the [Syrup UI](https://syrup.fi/) to set permissions.
+
+### Querying Permissions with Subgraph
+
+For those interested in the technical details, you can query the subgraph to check permission information. This is useful for verifying the current state of permissions.
+
+**Example Query**
 
 The following GraphQL query can be used to retrieve the necessary permission information for a specific pool and account:
 
@@ -100,20 +111,16 @@ The following GraphQL query can be used to retrieve the necessary permission inf
 }
 ```
 
-### API Endpoint
+**API Endpoint**
 
-Use the following endpoint to execute the query:
+Use the following endpoint to execute the query: `https://api.maple.finance/v2/graphql`
 
-`https://api.maple.finance/v2/graphql`
+**Explanation**
 
-### Explanation
+- **poolV2**: Retrieves pool permission details.
+- **account**: Retrieves the `permissionsBitmap` for the account.
 
-- **poolV2**: This section of the query retrieves information about the pool, including its permission level, and bitmaps for pool-level and function-level permissions if applicable.
-- **account**: This section retrieves the `permissionsBitmap` for a specific account, which indicates the permissions granted to that account.
-
-Ensure that the account's `permissionsBitmap` meets or exceeds the pool's requirements before attempting to deposit.
-
-For more details on how permissions are managed, refer to the [Pool Permission Manager documentation](technical-resources/singletons/pool-permission-manager.md).
+Ensure that the account's `permissionsBitmap` meets or exceeds the pool's requirements before attempting to deposit. For more details on permissions, refer to the [Pool Permission Manager documentation](technical-resources/singletons/pool-permission-manager.md).
 
 ## Example Integration with React
 

--- a/technical-resources/sdk/usage-guide.md
+++ b/technical-resources/sdk/usage-guide.md
@@ -104,7 +104,7 @@ The following GraphQL query can be used to retrieve the necessary permission inf
 
 Use the following endpoint to execute the query:
 
-`https://api.maple-dev.finance/v2/graphql`
+`https://api.maple.finance/v2/graphql`
 
 ### Explanation
 

--- a/technical-resources/sdk/usage-guide.md
+++ b/technical-resources/sdk/usage-guide.md
@@ -76,6 +76,45 @@ const poolContract = pool.core.connect(poolAddress, signer);
 const method = await (await poolContract.deposit(depositAmount)).wait();
 ```
 
+## Checking Permissions with Subgraph
+
+Before a wallet can deposit into a Maple pool, it must have a sufficient `permissionsBitmap` set. This bitmap must meet or exceed the requirements specified by the pool's configuration. You can query the subgraph to check this information.
+
+### Example Query
+
+The following GraphQL query can be used to retrieve the necessary permission information for a specific pool and account:
+
+```graphql
+{
+  poolV2(id: "0xc1dd3f011290f212227170f0d02f511ebf57e433") {
+    permissionLevel
+    poolLevelBitmap
+    functionLevelBitmaps {
+      id
+      bitmap
+    }
+  }
+  account(id: "0xAccountId") {
+    permissionsBitmap
+  }
+}
+```
+
+### API Endpoint
+
+Use the following endpoint to execute the query:
+
+`https://api.maple-dev.finance/v2/graphql`
+
+### Explanation
+
+- **poolV2**: This section of the query retrieves information about the pool, including its permission level, and bitmaps for pool-level and function-level permissions if applicable.
+- **account**: This section retrieves the `permissionsBitmap` for a specific account, which indicates the permissions granted to that account.
+
+Ensure that the account's `permissionsBitmap` meets or exceeds the pool's requirements before attempting to deposit.
+
+For more details on how permissions are managed, refer to the [Pool Permission Manager documentation](technical-resources/singletons/pool-permission-manager.md).
+
 ## Example Integration with React
 
 This section provides a practical example of how to integrate the Maple SDK into a React application. This example demonstrates connecting to a wallet, approving a token transfer, depositing into a pool, and requesting a withdrawal.
@@ -87,7 +126,8 @@ Ensure you have the following installed and set up:
 - Node.js and npm
 - A React application (created using `create-react-app` or similar)
 - ethers v5 installed in your project
-- MetaMask extension installed in your browser
+- MetaMask/Rabby extension installed in your browser
+- A wallet with sufficient permissions to interact with the pool (see [Checking Permissions with Subgraph](#checking-permissions-with-subgraph))
 
 ### Step-by-Step Guide
 
@@ -109,7 +149,7 @@ Ensure you have the following installed and set up:
    import { addresses, poolV2, environmentMocks } from '@maplelabs/maple-js';
 
    const PROJECT = 'mainnet-prod';
-   const POOL_ADDRESS = '0xpoolAddress';
+   const POOL_ADDRESS = '0xc1dd3f011290f212227170f0d02f511ebf57e433'; // Blue Chip Secured Pool
    const ONE_HUNDRED_USDC = BigNumber.from(100).mul(10 ** 6);
 
    async function getPoolContract(poolAddress: string) {

--- a/technical-resources/sdk/usage-guide.md
+++ b/technical-resources/sdk/usage-guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Maple SDK simplifies interaction with Maple Protocol smart contracts on Ethereum. It supports Mainnet, Base, and Sepolia networks, with production and development environments.This guide provides both conceptual understanding and practical examples, including a full integration with a React application.
+The Maple SDK simplifies interaction with Maple Protocol smart contracts on Ethereum. It supports Mainnet, Base, and Sepolia networks, with production and development environments. This guide provides both conceptual understanding and practical examples, including a full integration with a React application.
 
 There are three networks:
 


### PR DESCRIPTION
Adds `Example Integration with React` section to the SDK docs with a "drop-in code" with txes:
- approve
- deposit
- requestRedeem

This is how it would look in a browser:
<img width="1687" alt="Screenshot 2024-11-01 at 17 23 00" src="https://github.com/user-attachments/assets/86b61c5b-d67e-47bd-9af8-0abde7224060">
